### PR TITLE
add some includes to fix compilation warnings/problems

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -9,6 +9,9 @@
 #include "console.h"
 #include "ftp.h"
 
+// only for mkdir, used when creating the "logs" directory
+#include <sys/stat.h>
+
 #include <switch.h>
 
 #include "util.h"

--- a/source/util.c
+++ b/source/util.c
@@ -2,8 +2,11 @@
 #include <stdio.h>
 #include <malloc.h>
 #include <math.h>
+#include <unistd.h>
 
 #include <switch.h>
+
+#include "mp3.h"
 
 void fatalLater(Result err)
 {


### PR DESCRIPTION
This commit gets rid of the following gcc warnings:

- `sys-ftpd/source/main.c:129:9: warning: implicit declaration of function 'mkdir'; did you mean 'rmdir'?`
- `sys-ftpd/source/util.c:69:9: warning: implicit declaration of function 'playMp3'`
- `sys-ftpd/source/util.c:71:9: warning: implicit declaration of function 'unlink'`